### PR TITLE
[Metrics] - Increase memory and cpu for monitoring

### DIFF
--- a/install/roles/automation-hub/templates/acm/07-multicluster-observability.yaml.j2
+++ b/install/roles/automation-hub/templates/acm/07-multicluster-observability.yaml.j2
@@ -31,8 +31,8 @@ spec:
       replicas: 3
       resources:
         limits:
-          cpu: 4
-          memory: 15Gi
+          cpu: 6
+          memory: 26Gi
     retentionConfig:
       blockDuration: 2h
       deleteDelay: 48h

--- a/install/roles/automation-hub/templates/acm/07-multicluster-observability.yaml.j2
+++ b/install/roles/automation-hub/templates/acm/07-multicluster-observability.yaml.j2
@@ -31,8 +31,8 @@ spec:
       replicas: 3
       resources:
         limits:
-          cpu: 6
-          memory: 26Gi
+          cpu: 4
+          memory: 15Gi
     retentionConfig:
       blockDuration: 2h
       deleteDelay: 48h

--- a/install/roles/automation-hub/templates/infra-machine-sets.yaml.j2
+++ b/install/roles/automation-hub/templates/infra-machine-sets.yaml.j2
@@ -9,7 +9,7 @@ metadata:
     machine.openshift.io/cluster-api-machine-role: worker
     machine.openshift.io/cluster-api-machine-type: worker
 spec:
-  replicas: 2
+  replicas: 3
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: {{ clusterId }}


### PR DESCRIPTION
Currently one of our statefulsets i.e., `observability-thanos-receive-default-0` is failing because OOMKilled. This PR increases default size of such resource to prevent this problem.