### PR TITLE
Update memory for ArgoCD controllers

### DIFF
--- a/install/roles/automation-hub/templates/argo/install/argocd.yaml
+++ b/install/roles/automation-hub/templates/argo/install/argocd.yaml
@@ -109,10 +109,10 @@ spec:
     resources:
       limits:
         cpu: '2'
-        memory: 3Gi
+        memory: 4Gi
       requests:
         cpu: 250m
-        memory: 1Gi
+        memory: 2Gi
     sharding: {}
     tls:
       ca:


### PR DESCRIPTION
It seems that when one removes all ApplicationsSets and re-installs it all one could end up where the controller will be stuck in the `OOMKilled` cycle. This PR updates resources and resolves such problems.
```
tealc-gitops-application-controller-0                           0/1     OOMKilled   3 (1s ago)   7m8s
```