### PR TITLE
Make upgrade of cluster less often + improve status of upgrade pipeline

### DIFF
--- a/install/roles/automation-hub/templates/tekton/pipelines/infra/upgrade-worker-cluster.yaml.j2
+++ b/install/roles/automation-hub/templates/tekton/pipelines/infra/upgrade-worker-cluster.yaml.j2
@@ -50,13 +50,22 @@ spec:
               sleep 120
 
               IS_UPGRADING="true"
-              while [[ $IS_UPGRADING == "true" ]]; do
+              LOOP_COUNTER=0
+              COUNTER=180
+              while [[ $IS_UPGRADING == "true" ]] && [[ $LOOP_COUNTER -gt $COUNTER ]]; do
+                LOOP_COUNTER=$((LOOP_COUNTER + 1))
+
+                if [[ $COUNTER -gt $COUNTER ]]; then
+                  echo "Maximum loop count of $COUNTER reached. Exiting."
+                  exit 1
+                fi
+
                 if [[ "$(oc get clusterversion -o=jsonpath='{.items[0].status.history[0].completionTime}')" == "null" ]]; then
                   echo "Cluster is in upgrade state"
                 else
                   IS_UPGRADING="false"
                 fi
-                sleep 10
+                sleep 60
               done
   finally:
     - name: notify-slack
@@ -150,7 +159,7 @@ metadata:
 spec:
   failedJobsHistoryLimit: 1
   successfulJobsHistoryLimit: 1
-  schedule: "0 */12 * * *"
+  schedule: "0 0 * * 2" # every Tuesday
   jobTemplate:
     spec:
       template:

--- a/install/roles/automation-hub/templates/tekton/pipelines/infra/upgrade-worker-cluster.yaml.j2
+++ b/install/roles/automation-hub/templates/tekton/pipelines/infra/upgrade-worker-cluster.yaml.j2
@@ -52,10 +52,10 @@ spec:
               IS_UPGRADING="true"
               LOOP_COUNTER=0
               COUNTER=180
-              while [[ $IS_UPGRADING == "true" ]] && [[ $LOOP_COUNTER -gt $COUNTER ]]; do
+              while [[ $IS_UPGRADING == "true" ]] && [[ $LOOP_COUNTER -lt $COUNTER ]]; do
                 LOOP_COUNTER=$((LOOP_COUNTER + 1))
 
-                if [[ $COUNTER -gt $COUNTER ]]; then
+                if [[ $LOOP_COUNTER -gt $COUNTER ]]; then
                   echo "Maximum loop count of $COUNTER reached. Exiting."
                   exit 1
                 fi

--- a/install/roles/automation-hub/templates/tekton/pipelines/infra/upgrade-worker-cluster.yaml.j2
+++ b/install/roles/automation-hub/templates/tekton/pipelines/infra/upgrade-worker-cluster.yaml.j2
@@ -52,7 +52,7 @@ spec:
               IS_UPGRADING="true"
               LOOP_COUNTER=0
               COUNTER=180
-              while [[ $IS_UPGRADING == "true" ]] && [[ $LOOP_COUNTER -lt $COUNTER ]]; do
+              while [[ $IS_UPGRADING == "true" ]] && [[ $LOOP_COUNTER -le $COUNTER ]]; do
                 LOOP_COUNTER=$((LOOP_COUNTER + 1))
 
                 if [[ $LOOP_COUNTER -gt $COUNTER ]]; then


### PR DESCRIPTION
After investigate -> ACM cannot trigger upgrade automatically, so we can continue with our pipelines for upgrade but less often and with proper reporting.